### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a best tracker from Russia! Enjoy it!
 
 ### Install
 
-``` 
+```
 $ npm install gitbook-plugin-yametrika
 ```
 
@@ -53,6 +53,25 @@ You can customize the tracker object by passing additional configuration options
     }
 }
 ```
+
+When using GitBook 3, the whole configuration settings should be set directly in the `"yametrika"` property, using the default configuration for the API:
+``` json
+{
+    "plugins": ["yametrika"],
+    "pluginsConfig": {
+        "yametrika": {
+            "id": 11111111,
+            "webvisor": true,
+            "clickmap": true,
+            "trackLinks": true,
+            "accurateTrackBounce": true,
+            "trackHash": true,
+            "ut": "noindex"
+        }
+    }
+}
+```
+
 Available for customize options:
 - Webvisor (Вебвизор)
 - Clickmap (Карта кликов)
@@ -69,7 +88,7 @@ default track options status:
 
 - Webvisor (Вебвизор) - **false** (!new)
 - Clickmap (Карта кликов) - **false** (!new)
-- TrackLinks (Внешние ссылки, загрузки файлов и отчёт по кнопке «Поделиться») - **false** (!new) 
+- TrackLinks (Внешние ссылки, загрузки файлов и отчёт по кнопке «Поделиться») - **false** (!new)
 - AccurateTrackBounce (Точный показатель отказов) - **false**  (!new)
 - Informer (Информер) - **false**
 - Ut (Запрет на индексацию страниц) - **false**

--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,33 @@
+{% extends template.self %}
+
+{% block javascript %}
+    {{ super() }}
+    <script type='text/javascript'>
+        (function (d, w, c) {
+            (w[c] = w[c] || []).push(function() {
+                try {
+                    w.yaCounter{{ config.pluginsConfig.yametrika.id }} = new Ya.Metrika({{ config.pluginsConfig.yametrika|dump|safe }});
+                } catch(e) { }
+            });
+            var n = d.getElementsByTagName('script')[0],
+                s = d.createElement('script'),
+                f = function () {
+                    n.parentNode.insertBefore(s, n);
+                };
+
+            s.type = 'text/javascript';
+            s.async = true;
+            s.src = (d.location.protocol == 'https:' ? 'https:' : 'http:') + '//mc.yandex.ru/metrika/watch.js';
+            if (w.opera == '[object Opera]') {
+                d.addEventListener('DOMContentLoaded', f, false);
+            } else {
+                f();
+            }
+        })(document, window, 'yandex_metrika_callbacks');
+    </script>
+    <noscript>
+        <div>
+            <img src="//mc.yandex.ru/watch/{{ config.pluginsConfig.yametrika.id }}" style="position:absolute; left:-9999px;" alt=""/>
+        </div>
+    </noscript>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -3,40 +3,6 @@ module.exports = {
         assets: "./book",
         js: [
             "plugin.js"
-        ],
-        html: {
-            "body:end": function() {
-                var config = this.options.pluginsConfig.yametrika || {},
-                    settings = "";
-
-                if (!config.number) {
-                    throw "Need to option 'number' for Yandex Metrika plugin";
-                }
-
-                if(typeof config.settings === 'object' && config.settings !== null) {
-
-                    for (option in config.settings) {
-
-                        if (typeof config.settings[option] !== 'string') {
-
-                            settings += ", " + option + ":" + config.settings[option];
-
-                        } else {
-
-                            settings += ", " + option + ":'" + config.settings[option] + "'";
-                        }                        
-                    }
-                }
-
-                return "<script type='text/javascript'>(function (d, w, c) { (w[c] = w[c] || []).push(function() { try { "
-                + "w.yaCounter" + config.number + " = new Ya.Metrika({id:" + config.number + settings + "});"
-                + " } catch(e) { } }); var n = d.getElementsByTagName('script')"
-                + "[0], s = d.createElement('script'), f = function () { n.parentNode.insertBefore(s, n); }; s.type = "
-                + "'text/javascript'; s.async = true; s.src = (d.location.protocol == 'https:' ? 'https:' : 'http:') + "
-                + "'//mc.yandex.ru/metrika/watch.js'; if (w.opera == '[object Opera]') { d.addEventListener('DOMContentLoaded'"
-                + ", f, false); } else { f(); } })(document, window, 'yandex_metrika_callbacks');</script><noscript><div><img "
-                + "src='//mc.yandex.ru/watch/" + config.number + "' style='position:absolute; left:-9999px;' alt=''/></div></noscript>";
-            }
-        }
+        ]
     }
 };

--- a/package.json
+++ b/package.json
@@ -18,5 +18,14 @@
     "metrika"
   ],
   "author": "mikaspell",
-  "license": "MIT"
+  "license": "MIT",
+  "gitbook": {
+    "properties": {
+      "id": {
+        "type": "number",
+        "description": "Yandex Metrika tracking ID",
+        "required": true
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
It includes the tracking script using GitBook 3 templating. I also added the minimum configuration to `package.json` and made it inline (other settings should be set directly in the `yametrika` property). This allows to use the user's configuration directly when creating the `new Ya.Metrika()` call:

``` JavaScript
new Ya.Metrika({{ config.pluginsConfig.yametrika|dump|safe }});
```

Hence, I reflected these changes to the `README.md` file.

Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

Your new version's `package.json` must specify the new gitbook engine:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
